### PR TITLE
Fixing error when trying to run autobypass update

### DIFF
--- a/aard_autobypass.xml
+++ b/aard_autobypass.xml
@@ -151,7 +151,8 @@ Vira grants you the "Add +1 bypass (all classes)" wish, at a cost of 13900 quest
 <![CDATA[
 require "gmcphelper"
 require "json"
-
+require "wait"
+require "async"
 
 ----------------------- Help File Code -----------------------
 local help_topics = {


### PR DESCRIPTION
This addresses this error:
```
Run-time error
Plugin: Aardwolf_Autobypass (called from world: Aardwolf)
Function/Sub: update_check_alias called by alias
Reason: processing alias ""
[string "Plugin: Aardwolf_Autobypass"]:767: attempt to index global 'wait' (a nil value)
stack traceback:
        [string "Plugin: Aardwolf_Autobypass"]:767: in function 'update_plugin'
        [string "Plugin: Aardwolf_Autobypass"]:737: in function <[string "Plugin: Aardwolf_Autobypass"]:736>
``